### PR TITLE
Unicode escape character URL fix

### DIFF
--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - `[Backend]` Moved the userscript CSS to a standalone file which is loaded via `@resource`.
 
+### Fixed
+- Unicode escape characters in URL now properly work.
+
 ## [2017-07-27]
 ### Added
 - Support for Fallen Angels Scans.

--- a/public/userscripts/manga-tracker.meta.js
+++ b/public/userscripts/manga-tracker.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Manga Tracker
 // @namespace    https://github.com/DakuTree/userscripts
-// @version      1.7.27
+// @version      1.7.28
 // @downloadURL  https://trackr.moe/userscripts/manga-tracker.user.js
 // @updateURL    https://trackr.moe/userscripts/manga-tracker.meta.js
 // ==/UserScript==

--- a/public/userscripts/manga-tracker.user.js
+++ b/public/userscripts/manga-tracker.user.js
@@ -34,7 +34,7 @@
 // @include      /^https?:\/\/manga\.fascans\.com\/[a-z]+\/[a-zA-Z0-9_-]+\/[0-9]+[\/]*[0-9]*$/
 // @include      /^http?:\/\/mangaichiscans\.mokkori\.fr\/fs\/read\/.*?\/[a-z]+\/[0-9]+\/[0-9]+(\/.*)?$/
 // @updated      2017-07-29
-// @version      1.7.27
+// @version      1.7.28
 // @downloadURL  https://trackr.moe/userscripts/manga-tracker.user.js
 // @updateURL    https://trackr.moe/userscripts/manga-tracker.meta.js
 // @require      https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js

--- a/public/userscripts/manga-tracker.user.js
+++ b/public/userscripts/manga-tracker.user.js
@@ -899,7 +899,7 @@ let base_site = {
 			this.viewerCustomImageList = $('#content').find('> script:first').html().match(/(https?:\\\/\\\/[^"]+)/g).filter(function(value, index, self) {
 				return self.indexOf(value) === index;
 			}).map(function(e) {
-				return e.replace(/\\/g, '');
+				return JSON.parse('"' + e.replace(/\"/g, '\\"') + '"');
 			});
 			this.page_count = this.viewerCustomImageList.length;
 		};


### PR DESCRIPTION
`https://reader.seaotterscans.com/content/comics/boku_to_rune_to_aoarashi_56ab4be32dc51/3_0_seirans_secret_56ac394274a9f/%E3%83%AB%E3%83%8D03_01.png`

The userscript failed to recognize to properly generate image URLs like this because of the escaped unicode characters in the HTML. 

This is how it looked in the code:
`https:\/\/reader.seaotterscans.com\/content\/comics\/boku_to_rune_to_aoarashi_56ab4be32dc51\/3_0_seirans_secret_56ac394274a9f\/\u30eb\u30cd03_01.png`